### PR TITLE
Parse not selected group ids for a Profile instead of selected

### DIFF
--- a/lib/openscap_parser/profile.rb
+++ b/lib/openscap_parser/profile.rb
@@ -31,14 +31,14 @@ module OpenscapParser
                                                       /@idref", RegexHandler).map(&:text)
     end
 
-    def selected_group_ids
-      # Look for selected group ids where the idref contains '_group_' that is not preceded by 'rule'
-      @selected_group_ids ||= @parsed_xml.xpath("select[@selected='true']
-                                                       [regex(@idref, '^((?!_rule_).)*?(_group_).*$')]
-                                                       /@idref", RegexHandler) &&
-                              @parsed_xml.xpath("select[@selected='true']
-                                                       [regex(@idref, '^((?!_rule_).)*?(_group_).*$')]
-                                                       /@idref", RegexHandler).map(&:text)
+    def unselected_group_ids
+      # Look for group ids that are not selected where the idref contains '_group_' that is not preceded by 'rule'
+      @unselected_group_ids ||= @parsed_xml.xpath("select[@selected='false']
+                                                         [regex(@idref, '^((?!_rule_).)*?(_group_).*$')]
+                                                         /@idref", RegexHandler) &&
+                                @parsed_xml.xpath("select[@selected='false']
+                                                         [regex(@idref, '^((?!_rule_).)*?(_group_).*$')]
+                                                         /@idref", RegexHandler).map(&:text)
     end
 
     def selected_entity_ids

--- a/test/openscap_parser/test_result_file_test.rb
+++ b/test/openscap_parser/test_result_file_test.rb
@@ -42,25 +42,16 @@ class TestResultFileTest < Minitest::Test
         refute_includes(@test_result_file2.benchmark.profiles.first.selected_rule_ids, "xccdf_org.ssgproject.content_group_rule_group_crypto")
       end
 
-      test 'profile_selected_group_ids' do
-        assert_equal(["xccdf_org.ssgproject.rules_group_crypto",
-                      "xccdf_org.ssgproject_rules.content_group_crypto",
-                      "xccdf_org.ssgproject.contentrule_group_crypto",
-                      "xccdf_org.ssgproject.content_group_rule_crypto",
-                      "xccdf_org.ssgproject.content_group_rule_group_crypto",
-                      "xccdf_org.ssgproject.content_group_endpoint_rule_security_software",
-                      "xccdf_org.ssgproject.content_group_nfs_configuring_all_machines",
-                      "xccdf_org.ssgproject.content_group_nfs_client_or_server_not_both",
-                      "xccdf_org.ssgproject.content_group_nfs_configure_fixed_ports",
-                      "xccdf_org.ssgproject.content_group_mounting_remote_filesystems"],
-                     @test_result_file2.benchmark.profiles.first.selected_group_ids)
+      test 'profile_unselected_group_ids' do
+        assert_equal(186, @test_result_file.benchmark.profiles.first.unselected_group_ids.count)
+        assert_includes(@test_result_file.benchmark.profiles.first.unselected_group_ids, "xccdf_org.ssgproject.content_group_mcafee_security_software")
+        assert_includes(@test_result_file.benchmark.profiles.first.unselected_group_ids, "xccdf_org.ssgproject.content_group_mcafee_hbss_software")
+        assert_includes(@test_result_file.benchmark.profiles.first.unselected_group_ids, "xccdf_org.ssgproject.content_group_certified-vendor")
+        assert_includes(@test_result_file.benchmark.profiles.first.unselected_group_ids, "xccdf_org.ssgproject.content_group_restrictions")
       end
 
       test 'profile_selected_entity_ids' do
-        all_selected_ids = @test_result_file2.benchmark.profiles.first.selected_rule_ids +
-                           @test_result_file2.benchmark.profiles.first.selected_group_ids
         assert_equal(248, @test_result_file2.benchmark.profiles.first.selected_entity_ids.length)
-        assert_equal(all_selected_ids.sort, @test_result_file2.benchmark.profiles.first.selected_entity_ids.sort)
       end
     end
 


### PR DESCRIPTION
Our selected_group_ids method was not working correctly. We were looking for groups under a Profile where `selected="true"` but according to the openscap team, they do not explicitly mark groups as true using `selected="true"`. Instead they will explicitly mark a group as unselected using `selected="false"` and then it can be assumed that all other groups within the benchmark are selected.

Watson from the openscap google chat gave advice on how to fix our selected_group_ids method so that are getting the correct groups. He said that we can look for the groups that are `selected="false"`, e.g.: `<xccdf-1.2:select idref="xccdf_org.ssgproject.content_group_account_expiration" selected="false"/>`, and assume that a group not explicitly unselected is selected. So I updated the `selected_group_ids` to `not_selected_group_ids` and parsed all group idrefs that had `selected="false"` under the Profile. Now during the import in compliance-backend, we will know that every rule_group in the benchmark is selected if it is not included in `not_selected_group_ids`.
