### PR TITLE
RHICOMPL-3348: Add Values to openscap parser

### DIFF
--- a/lib/openscap_parser.rb
+++ b/lib/openscap_parser.rb
@@ -7,6 +7,7 @@ require 'openscap_parser/test_results'
 require 'openscap_parser/profiles'
 require 'openscap_parser/rules'
 require 'openscap_parser/groups'
+require 'openscap_parser/value_definitions'
 require 'openscap_parser/rule_results'
 require 'openscap_parser/tailorings'
 

--- a/lib/openscap_parser/benchmark.rb
+++ b/lib/openscap_parser/benchmark.rb
@@ -6,6 +6,7 @@ require 'openscap_parser/rules'
 require 'openscap_parser/profiles'
 require 'openscap_parser/rule_references'
 require 'openscap_parser/groups'
+require 'openscap_parser/value_definitions'
 
 # Mimics openscap-ruby Benchmark interface
 module OpenscapParser
@@ -15,6 +16,7 @@ module OpenscapParser
     include OpenscapParser::RuleReferences
     include OpenscapParser::Profiles
     include OpenscapParser::Groups
+    include OpenscapParser::ValueDefinitions
 
     def id
       @id ||= @parsed_xml['id']

--- a/lib/openscap_parser/rule.rb
+++ b/lib/openscap_parser/rule.rb
@@ -83,6 +83,10 @@ module OpenscapParser
       end
     end
 
+    def values
+      parsed_xml.xpath("check/check-export").map { |r| r.at_xpath('@value-id')&.text }
+    end
+
     def to_h
       {
         :id => id,
@@ -95,7 +99,8 @@ module OpenscapParser
         :rationale => rationale,
         :identifier => rule_identifier.to_h,
         :parent_id => parent_id,
-        :parent_type => parent_type
+        :parent_type => parent_type,
+        :values => values
       }
     end
   end

--- a/lib/openscap_parser/value_definition.rb
+++ b/lib/openscap_parser/value_definition.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+module OpenscapParser
+  class ValueDefinition < XmlNode
+    include OpenscapParser::Util
+
+    def id
+      @id ||= parsed_xml['id']
+    end
+
+    def description
+      @description ||= newline_to_whitespace(parsed_xml.at_css('description')&.text)
+    end
+
+    def title
+      @title ||= parsed_xml.at_css('title')&.text
+    end
+
+    def type
+      @type ||= parsed_xml['type'] || 'string'
+    end
+
+    def lower_bound
+      @lower_bound ||= begin
+        lower_bound_element = parsed_xml.at_xpath("lower-bound[@selector='']") || parsed_xml.at_xpath('lower-bound[not(@selector)]')
+        lower_bound_element&.text
+      end
+    end
+
+    def upper_bound
+      @upper_bound ||= begin
+        upper_bound_element = parsed_xml.at_xpath("upper-bound[@selector='']") || parsed_xml.at_xpath('upper-bound[not(@selector)]')
+        upper_bound_element&.text
+      end
+    end
+
+    def default_value
+      # The default value is the value element with a empty or absent @selector
+      # If there is no value element with an empty or absent @selector, the first value in
+      # the top down processing shall be the default element
+      @default_value ||= begin
+        value_element = parsed_xml.at_xpath("value[@selector='']") || parsed_xml.at_xpath('value[not(@selector)]') || parsed_xml.xpath("value")[0]
+        value_element&.text
+      end
+    end
+
+    def to_h
+      {
+        :id => id,
+        :title => title,
+        :description => description,
+        :type => type,
+        :lower_bound => lower_bound,
+        :upper_bound => upper_bound,
+        :default_value => default_value
+      }
+    end
+  end
+end

--- a/lib/openscap_parser/value_definitions.rb
+++ b/lib/openscap_parser/value_definitions.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'openscap_parser/value_definition'
+
+module OpenscapParser
+  # Methods related to parsing values
+  module ValueDefinitions
+    def self.included(base)
+      base.class_eval do
+        def value_definitions
+          @value_definitions ||= value_definition_nodes.map do |vdn|
+            ValueDefinition.new(parsed_xml: vdn)
+          end
+        end
+
+        def value_definition_nodes(xpath = ".//Value")
+          xpath_nodes(xpath)
+        end
+      end
+    end
+  end
+end

--- a/lib/openscap_parser/version.rb
+++ b/lib/openscap_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenscapParser
-  VERSION = "1.4.0"
+  VERSION = "1.5.0"
 end

--- a/test/openscap_parser/test_result_file_test.rb
+++ b/test/openscap_parser/test_result_file_test.rb
@@ -182,6 +182,36 @@ class TestResultFileTest < Minitest::Test
       end
     end
 
+    context 'value_definitions' do
+      test 'value_description' do
+        assert_match(/^Specify the email address for designated personnel if baseline configurations are changed in an unauthorized manner./,
+                     @test_result_file2.benchmark.value_definitions.first.description)
+      end
+
+      test 'type' do
+        assert_equal("string", @test_result_file2.benchmark.value_definitions[0].type)
+        assert_equal("string", @test_result_file2.benchmark.value_definitions[1].type)
+        assert_equal("number", @test_result_file2.benchmark.value_definitions[4].type)
+      end
+
+      test 'lower bound' do
+        assert_equal(nil, @test_result_file2.benchmark.value_definitions[0].lower_bound)
+        assert_equal("0", @test_result_file2.benchmark.value_definitions[4].lower_bound)
+      end
+
+      test 'upper bound' do
+        assert_equal(nil, @test_result_file2.benchmark.value_definitions[0].upper_bound)
+        assert_equal("40000000", @test_result_file2.benchmark.value_definitions[4].upper_bound)
+      end
+
+      test 'default value' do
+        assert_equal("51882M", @test_result_file2.benchmark.value_definitions[0].default_value)
+        assert_equal("512M", @test_result_file2.benchmark.value_definitions[1].default_value)
+        assert_equal("3h", @test_result_file2.benchmark.value_definitions[2].default_value)
+        assert_equal("DEFAULT", @test_result_file2.benchmark.value_definitions[3].default_value)
+      end
+    end
+
     context 'rule_references' do
       test 'rule references' do
         rule = @test_result_file.benchmark.rules.find do |r|

--- a/test/openscap_parser/test_result_file_test.rb
+++ b/test/openscap_parser/test_result_file_test.rb
@@ -180,6 +180,13 @@ class TestResultFileTest < Minitest::Test
         assert_match(/^Group/,
                      @test_result_file2.benchmark.rules[1].parent_type)
       end
+
+      test 'values' do
+        rule = @test_result_file2.benchmark.rules.select { |r| r.id == "xccdf_org.ssgproject.content_rule_accounts_password_pam_pwhistory_remember_password_auth" }
+        assert_equal(["xccdf_org.ssgproject.content_value_var_password_pam_remember_control_flag", "xccdf_org.ssgproject.content_value_var_password_pam_remember"],
+                     rule[0].values)
+        assert_equal([], @test_result_file2.benchmark.rules[1].values)
+      end
     end
 
     context 'value_definitions' do


### PR DESCRIPTION
The purpose of this PR is to: 
- Parse Value definitions to get the necessary info about Values under a benchmark
<img width="924" alt="Screenshot 2022-11-21 at 2 34 16 PM" src="https://user-images.githubusercontent.com/87209745/203143227-a1e7ded3-dfaf-4885-ae82-dbe137c9d50b.png">

- Parse the `check` / `check-export` element that can be found under Rule definitions. A Rule can have a `check-export` element under it's definition with one or more `@value-id` attributes and this would mean that the rule uses those values
<img width="886" alt="Screenshot 2022-11-21 at 2 32 08 PM" src="https://user-images.githubusercontent.com/87209745/203142850-aca601f5-3e18-4400-8bf3-43dd84de020f.png">
