### PR TITLE
feat(RuleReference): RHICOMPL-3434 implement the to_h method

### DIFF
--- a/lib/openscap_parser/rule_reference.rb
+++ b/lib/openscap_parser/rule_reference.rb
@@ -10,5 +10,12 @@ module OpenscapParser
     def label
       @label ||= @parsed_xml && @parsed_xml.text
     end
+
+    def to_h
+      {
+        href: href,
+        label: label
+      }
+    end
   end
 end

--- a/lib/openscap_parser/version.rb
+++ b/lib/openscap_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenscapParser
-  VERSION = "1.3.0"
+  VERSION = "1.3.1"
 end


### PR DESCRIPTION
This method should help us with passing rule references to the JSON array field in the rules table of the compliance DB. Also increases consistency with other objects implementing the same method.