### PR TITLE
feat(Group): RHICOMPL-3454 provide a list of parent IDs

### DIFF
--- a/lib/openscap_parser/group.rb
+++ b/lib/openscap_parser/group.rb
@@ -48,6 +48,10 @@ module OpenscapParser
       @parent_id = parsed_xml.xpath('../@id').to_s
     end
 
+    def parent_ids
+      @parent_ids = parsed_xml.xpath('ancestor::Group/@id').map(&:value)
+    end
+
     def parent_type
       if parsed_xml.xpath("name(..)='Group'")
         @parent_type = 'Group'

--- a/lib/openscap_parser/version.rb
+++ b/lib/openscap_parser/version.rb
@@ -1,3 +1,3 @@
 module OpenscapParser
-  VERSION = "1.3.1"
+  VERSION = "1.4.0"
 end


### PR DESCRIPTION
It is necessary for the ancestry gem when storing hierarchy in a database.

http://www.javabyexamples.com/xpath-select-parent-or-ancestor-nodes